### PR TITLE
Fix: fix position sticky on phone view

### DIFF
--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -23,6 +23,7 @@ a {
 }
 
 main {
+    overflow: hidden;
     max-width: 1440px;
     width: 100%;
     margin: auto;


### PR DESCRIPTION
вам просто нужно было добавить `overflow: hidden;` в main, чтобы это работало

![bug](https://github.com/user-attachments/assets/854b6b34-cf9e-4e57-b0cb-446f6df85bad)

